### PR TITLE
chore: Update message for old blips

### DIFF
--- a/config.json
+++ b/config.json
@@ -100,7 +100,7 @@
       "zoomIn": "Zoom in",
       "filterByTag": "Filter by Tag",
       "footer": "The Community Health Toolkit (CHT) is a project by a group of leading organizations who have come together to support the development of digital health initiatives in the hardest-to-reach areas. It provides a collection of open source technologies and open access design, technical, and implementer resources that help you build and deploy digital tools for community health. Together, we envision a world where healthcare is of the highest attainable quality, equitable, accessible, and delivered by people who are trusted in their communities.",
-      "notUpdated": "This item was not updated in last three versions of the Radar. Should it have appeared in one of the more recent editions, there is a good chance it remains pertinent. However, if the item dates back further, its relevance may have diminished and our current evaluation could vary. Regrettably, our capacity to consistently revisit items from past Radar editions is limited.",
+      "notUpdated": "This item was not updated in last three versions of the Radar. Nevertheless, it remains pertinent.", 
       "notFound": "404 - Page not found",
       "pageAbout": "How to use the CHT Technology Radar for Implementers?",
       "pageOverview": "Technologies Overview",


### PR DESCRIPTION
Update the message for old blips so that it states that if a blip is older than three versions, it still remains relevant.

How it shows now:

![Screenshot 2024-09-30 at 16 40 42](https://github.com/user-attachments/assets/6d1a7a21-4fc7-497e-a7a3-34051d2d89cf)
