### PR TITLE
chore: add TRICC, cht-hack-js and cht-config-library in trial

### DIFF
--- a/radar/2025-02-14/cht-config-library.md
+++ b/radar/2025-02-14/cht-config-library.md
@@ -1,0 +1,8 @@
+---
+title:      "cht-config-library"
+ring:       trial
+quadrant:   languages-and-frameworks
+tags:       [app-building]
+---
+ 
+[cht-config-library](https://github.com/jkuester/cht-config-library) contains examples of CHT configurations to illustrate certain features of the CHT. The goal of this library is to demonstrate functionality with simplicity and clarity and not to provide comprehensive production-ready configurations that map to real-world use cases.

--- a/radar/2025-02-14/cht-hack-js.md
+++ b/radar/2025-02-14/cht-hack-js.md
@@ -1,0 +1,10 @@
+---
+title:      "cht-hack-js"
+ring:       trial
+quadrant:   languages-and-frameworks
+tags:       [app-building]
+---
+ 
+[cht-hack-js](https://github.com/rukshn/cht-hack-js) is a JavaScript tool to modify the DOM content of the CHT. This extension can be used to customize the look and feel of a CHT form.
+
+Read more in the [dedicated blog post](https://ruky.me/hacking-cht-user-interface-with-javascript-to-format-content/).

--- a/radar/2025-02-14/tricc.md
+++ b/radar/2025-02-14/tricc.md
@@ -5,6 +5,6 @@ quadrant:   languages-and-frameworks
 tags:       [app-building]
 ---
 
-Tool for rapid implementation of clinical content ([TRICC](https://github.com/SwissTPH/tricc)) is an open-source tool developed by SwissTPH for building clinical content for CDSS/XFORM. It can be used to transform multiple tabs draw.io diagram into CHT (or ODK, both works).
+Tool for rapid implementation of clinical content ([TRICC](https://github.com/SwissTPH/tricc)) is an open-source tool developed by SwissTPH for building clinical content for CDSS/XFORM. It can be used to transform multiple tabs draw.io diagram into CHT (or ODK).
 
 Read more details on the [CHT Forum](https://forum.communityhealthtoolkit.org/t/cdss-visual-authring/4442).

--- a/radar/2025-02-14/tricc.md
+++ b/radar/2025-02-14/tricc.md
@@ -1,0 +1,10 @@
+---
+title:      "TRICC"
+ring:       trial
+quadrant:   languages-and-frameworks
+tags:       [app-building]
+---
+
+Tool for rapid implementation of clinical content ([TRICC](https://github.com/SwissTPH/tricc)) is an open-source tool developed by SwissTPH for building clinical content for CDSS/XFORM. It can be used to transform multiple tabs draw.io diagram into CHT (or ODK, both works).
+
+Read more details on the [CHT Forum](https://forum.communityhealthtoolkit.org/t/cdss-visual-authring/4442).


### PR DESCRIPTION
Add `TRICC`, `cht-hack-js` and `cht-config-library` in as `Trial` tools for the CHT Implementers.